### PR TITLE
feat: add `useJSONParse` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ How wasm code would be exported. (see [examples](#examples))
   - `async-module` will [compile][webassembly.compile] wasm code asynchronously, return promise of [WebAssembly.Module][]
   - `async-instance` will [instantiate][webassembly.instantiate] wasm code asynchronously, return promise of [WebAssembly.Instance][]
 
+### `useJSONParse`
+The WASM buffer is stored in the generated .js file as an array of numbers. If this option is `false`, that array will be represented in the source code using regular JavaScript syntax. If this option is `true`, that array will be stored as a string, and parsed via JSON.parse, e.g:
+
+```js
+Buffer.from(JSON.parse('[0,97,115,109...]'))
+```
+This [may improve parsing speed in the browser](https://v8.dev/blog/cost-of-javascript-2019#json), and will greatly improve compilation speed if any Webpack plugins parse the .js file as it prevents them from individually parsing every array element.
+
+- Type: `boolean`
+- Default: `false`
+
 <details><summary><i>webpack.config.js</i></summary>
 
 ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ module.exports = function(this: loader.LoaderContext, source: Buffer) {
   // if (options.export === 'buffer') return source; /*🤔*/
   return wasm2js(source, {
     export: options.export!,
+    useJSONParse: options.useJSONParse!,
     module: 'cjs',
     errorHandler: errMsg => this.emitError(errMsg)
   });

--- a/src/options.ts
+++ b/src/options.ts
@@ -12,6 +12,7 @@ export type WebAssemblyLoaderExportType =
 
 export interface WebAssemblyLoaderOptions {
   export?: WebAssemblyLoaderExportType;
+  useJSONParse?: boolean;
 }
 
 // bear in mind this is ran from dist

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -45,7 +45,7 @@ export default function(
       options.errorHandler
     );
 
-  const wrapped = wrap(source, options.module);
+  const wrapped = wrap(source, options.module, options.useJSONParse);
 
   switch (options.export) {
     case 'buffer':

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -45,19 +45,21 @@ export default function(
       options.errorHandler
     );
 
+  const wrapped = wrap(source, options.module);
+
   switch (options.export) {
     case 'buffer':
-      return wrap(source, options.module).asBuffer;
+      return wrapped.asBuffer;
     case 'instance':
-      return wrap(source, options.module).asWebAssembly.Instance;
+      return wrapped.asWebAssembly.Instance;
     case 'module':
-      return wrap(source, options.module).asWebAssembly.Module;
+      return wrapped.asWebAssembly.Module;
     case 'async':
-      return wrap(source, options.module).promiseWebAssembly.Both;
+      return wrapped.promiseWebAssembly.Both;
     case 'async-instance':
-      return wrap(source, options.module).promiseWebAssembly.Instance;
+      return wrapped.promiseWebAssembly.Instance;
     case 'async-module':
-      return wrap(source, options.module).promiseWebAssembly.Module;
+      return wrapped.promiseWebAssembly.Module;
     default:
       throw new Error(`exporting as "${options.export}" not available`);
   }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -49,17 +49,17 @@ export default function(
 
   switch (options.export) {
     case 'buffer':
-      return wrapped.asBuffer;
+      return wrapped.asBuffer();
     case 'instance':
-      return wrapped.asWebAssembly.Instance;
+      return wrapped.asWebAssembly.Instance();
     case 'module':
-      return wrapped.asWebAssembly.Module;
+      return wrapped.asWebAssembly.Module();
     case 'async':
-      return wrapped.promiseWebAssembly.Both;
+      return wrapped.promiseWebAssembly.Both();
     case 'async-instance':
-      return wrapped.promiseWebAssembly.Instance;
+      return wrapped.promiseWebAssembly.Instance();
     case 'async-module':
-      return wrapped.promiseWebAssembly.Module;
+      return wrapped.promiseWebAssembly.Module();
     default:
       throw new Error(`exporting as "${options.export}" not available`);
   }

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,7 +1,11 @@
 import { ModuleType } from './transform';
 
-function bufferAsString(buffer: Buffer) {
-  return `[${buffer.toJSON().data.join(',')}]`;
+function bufferAsString(buffer: Buffer, useJSONParse: boolean) {
+  const bufferArray = `[${buffer.toJSON().data.join(',')}]`;
+  if (!useJSONParse) return bufferArray;
+
+  // this array will only contain numbers, so no need to worry about escaping quotes
+  return `JSON.parse('${bufferArray}')`;
 }
 
 /** Wrap binary data as commonjs module so it can be imported by doing require(module)
@@ -9,12 +13,16 @@ function bufferAsString(buffer: Buffer) {
  * @return chainable object which represent `wrap this data as...`
  * @example return wrap(arrayBuffer).asWebAssembly.Module
  */
-export default function(buffer: Buffer, module?: ModuleType) {
+export default function(
+  buffer: Buffer,
+  module?: ModuleType,
+  useJSONParse: boolean = false
+) {
   let exportString = 'module.exports ='; // if (module === 'cjs')
 
   if (module === 'esm') exportString = 'export default';
 
-  const bufferString = `Buffer.from(${bufferAsString(buffer)})`;
+  const bufferString = `Buffer.from(${bufferAsString(buffer, useJSONParse)})`;
 
   return {
     asBuffer: () => `${exportString} ${bufferString}`,

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -12,26 +12,26 @@ export default function(buffer: Buffer, module?: ModuleType) {
   if (module === 'esm') exportString = 'export default';
 
   return {
-    asBuffer: `${exportString} Buffer.from([${data}])`,
+    asBuffer: () => `${exportString} Buffer.from([${data}])`,
     asWebAssembly: {
-      Module: `${exportString} new WebAssembly.Module(
+      Module: () => `${exportString} new WebAssembly.Module(
           Buffer.from([${data}])
         )`,
-      Instance: `${exportString} new WebAssembly.Instance(
+      Instance: () => `${exportString} new WebAssembly.Instance(
           new WebAssembly.Module(
             Buffer.from([${data}])
           )
         )`
     },
     promiseWebAssembly: {
-      Module: `${exportString} () => WebAssembly.compile(
+      Module: () => `${exportString} () => WebAssembly.compile(
           Buffer.from([${data}])
         )`,
-      Instance: `${exportString} importObject => WebAssembly.instantiate(
+      Instance: () => `${exportString} importObject => WebAssembly.instantiate(
           new WebAssembly.Module(Buffer.from([${data}])),
           importObject
         )`,
-      Both: `${exportString} importObject => WebAssembly.instantiate(
+      Both: () => `${exportString} importObject => WebAssembly.instantiate(
             Buffer.from([${data}]), importObject
         )`
     }

--- a/test/json-parse.test.ts
+++ b/test/json-parse.test.ts
@@ -1,0 +1,33 @@
+// tslint:disable:no-eval
+import { resolve } from 'path';
+import webpack = require('@webpack-contrib/test-utils');
+import on from './helpers/on';
+import { exportOptions } from './test-list';
+
+describe('When useJSONParse: true', () => {
+  let config: any;
+  beforeEach(() =>
+    (config = {
+      rules: [
+        {
+          test: /\.wasm$/,
+          type: 'javascript/auto',
+          use: {
+            loader: resolve(process.cwd(), 'dist')
+          }
+        }
+      ]
+    }));
+
+  test.each(exportOptions.all)(
+    'export as %s should use JSON.parse to improve parsing speed',
+    async opts => {
+      config.rules[0].use.options = { export: opts, useJSONParse: true };
+      const stats = await webpack('fixture.js', config);
+
+      const source = stats.compilation.assets['main.js'].source();
+
+      expect(source).toMatch("Buffer.from(JSON.parse('[");
+    }
+  );
+});

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -6,56 +6,64 @@ describe('When used as a Library', () => {
   /** @see https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format#The_simplest_module */
   const wasmBuffer = Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0, 0, 0]);
 
-  describe('export: "buffer"', () => {
-    const code = wasm2js(wasmBuffer, { export: 'buffer' });
-    const exportedModule = eval(code);
+  for (const useJSONParse of [false, true]) {
+    describe('export: "buffer"', () => {
+      const code = wasm2js(wasmBuffer, { export: 'buffer', useJSONParse });
+      const exportedModule = eval(code);
 
-    test('exported module to be identical with input', () =>
-      expect(exportedModule).toEqual(wasmBuffer));
-    test('exported as Buffer class', () =>
-      expect(exportedModule).toBeInstanceOf(Buffer));
-  });
+      test('exported module to be identical with input', () =>
+        expect(exportedModule).toEqual(wasmBuffer));
+      test('exported as Buffer class', () =>
+        expect(exportedModule).toBeInstanceOf(Buffer));
+    });
 
-  test('exported as WebAssembly.Module', () => {
-    const code = wasm2js(wasmBuffer, { export: 'module' });
-    const exportedModule = eval(code);
+    test('exported as WebAssembly.Module', () => {
+      const code = wasm2js(wasmBuffer, { export: 'module', useJSONParse });
+      const exportedModule = eval(code);
 
-    expect(exportedModule).toBeInstanceOf(WebAssembly.Module);
-  });
+      expect(exportedModule).toBeInstanceOf(WebAssembly.Module);
+    });
 
-  test('exported as WebAssembly.Instance', () => {
-    const code = wasm2js(wasmBuffer, { export: 'instance' });
-    const exportedModule = eval(code);
+    test('exported as WebAssembly.Instance', () => {
+      const code = wasm2js(wasmBuffer, { export: 'instance', useJSONParse });
+      const exportedModule = eval(code);
 
-    expect(exportedModule).toBeInstanceOf(WebAssembly.Instance);
-  });
+      expect(exportedModule).toBeInstanceOf(WebAssembly.Instance);
+    });
 
-  test('export of WebAssembly.compile', () => {
-    const code = wasm2js(wasmBuffer, { export: 'async-module' });
-    const exportedModule = eval(code);
+    test('export of WebAssembly.compile', () => {
+      const code = wasm2js(wasmBuffer, {
+        export: 'async-module',
+        useJSONParse
+      });
+      const exportedModule = eval(code);
 
-    expect(exportedModule).toBeFunction();
-    expect(exportedModule()).resolves.toBeInstanceOf(WebAssembly.Module);
-  });
+      expect(exportedModule).toBeFunction();
+      expect(exportedModule()).resolves.toBeInstanceOf(WebAssembly.Module);
+    });
 
-  test('export of WebAssembly.instantiate(WebAssembly.Module)', () => {
-    const code = wasm2js(wasmBuffer, { export: 'async-instance' });
-    const exportedModule = eval(code);
+    test('export of WebAssembly.instantiate(WebAssembly.Module)', () => {
+      const code = wasm2js(wasmBuffer, {
+        export: 'async-instance',
+        useJSONParse
+      });
+      const exportedModule = eval(code);
 
-    expect(exportedModule).toBeFunction();
-    expect(exportedModule()).resolves.toBeInstanceOf(WebAssembly.Instance);
-  });
+      expect(exportedModule).toBeFunction();
+      expect(exportedModule()).resolves.toBeInstanceOf(WebAssembly.Instance);
+    });
 
-  test('export of WebAssembly.instantiate(Buffer))', () => {
-    const code = wasm2js(wasmBuffer, { export: 'async' });
-    const exportedModule = eval(code);
+    test('export of WebAssembly.instantiate(Buffer))', () => {
+      const code = wasm2js(wasmBuffer, { export: 'async', useJSONParse });
+      const exportedModule = eval(code);
 
-    expect(exportedModule).toBeFunction();
-    expect(exportedModule()).resolves.toEqual(
-      expect.objectContaining({
-        instance: expect.any(WebAssembly.Instance),
-        module: expect.any(WebAssembly.Module)
-      })
-    );
-  });
+      expect(exportedModule).toBeFunction();
+      expect(exportedModule()).resolves.toEqual(
+        expect.objectContaining({
+          instance: expect.any(WebAssembly.Instance),
+          module: expect.any(WebAssembly.Module)
+        })
+      );
+    });
+  }
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **documentations**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Currently, the buffer of WASM code is stored in the generated JS bundle as an array, e.g:
```js
Buffer.from([0,97,115,109...])
```
This means that browsers, and any Webpack plugins that attempt to parse the generated code (e.g. minifiers), will have to individually parse every array element.

This PR adds the `useJSONParse` configuration option, which stringifies this array and wraps it in a `JSON.parse` call, like so:
```js
Buffer.from(JSON.parse('[0,97,115,109...]'))
```

This massively improved the compilation speed of my project, and [may have performance benefits for browsers as well](https://v8.dev/blog/cost-of-javascript-2019#json).

### Breaking Changes

N/A

### Additional Info

I also refactored the code a bit--in particular, `wrapper.ts` no longer returns one string per configuration type, and instead returns functions that return those strings. This means that instead of 6 strings being created per compile, only 1 is.