### PR TITLE
Fix webpack config example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,18 @@ How wasm code would be exported. (see [examples](#examples))
 
 ```js
 module.exports = {
-    rules: [{
-          test: /\.wasm$/,
-          type: "javascript/auto",
-          use: [{
-              loader: "webassembly-loader",
-              options: {
-                  export: "async"
-              }
-          }]
-    }]
+    module: {
+        rules: [{
+            test: /\.wasm$/,
+            type: "javascript/auto",
+            use: [{
+                loader: "webassembly-loader",
+                options: {
+                    export: "async"
+                }
+            }]
+        }]
+    }
 }
 ```
 </details>


### PR DESCRIPTION
I'm really a webpack noob, so please forgive me if I'm missing something obvious here. But according to the [docs](https://webpack.js.org/configuration/module/#modulerules) the key to define rules is `module.rules`?



This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **documentations**
- [ ] **metadata update**

### Motivation / Use-Case
`npx webpack` wouldn't run with the given example config

### Breaking Changes

none

### Additional Info
